### PR TITLE
planner: rewrite avg for mpp

### DIFF
--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -1195,7 +1195,6 @@ func (b *PlanBuilder) buildProjection(ctx context.Context, p LogicalPlan, fields
 		if !field.Auxiliary {
 			oldLen++
 		}
-
 		isWindowFuncField := ast.HasWindowFlag(field.Expr)
 		// Although window functions occurs in the select fields, but it has to be processed after having clause.
 		// So when we build the projection for select fields, we need to skip the window function.
@@ -2128,7 +2127,30 @@ func (b *PlanBuilder) extractAggFuncsInSelectFields(fields []*ast.SelectField) (
 		n, _ := f.Expr.Accept(extractor)
 		f.Expr = n.(ast.ExprNode)
 	}
-	aggList := extractor.AggFuncs
+	aggList := make([]*ast.AggregateFuncExpr, 0, len(extractor.AggFuncs)*2)
+	if b.ctx.GetSessionVars().AllowMPPExecution {
+		for _, aggf := range extractor.AggFuncs {
+			if aggf.F == ast.AggFuncAvg {
+				avgCount := *aggf
+				avgCount.F = ast.AggFuncCount
+				avgCount.Args = []ast.ExprNode{aggf.Args[0]}
+				aggList = append(aggList, &avgCount)
+				avgSum := *aggf
+				avgSum.F = ast.AggFuncSum
+				avgSum.Args = []ast.ExprNode{aggf.Args[0]}
+				aggList = append(aggList, &avgSum)
+				// case count(arg) when 0 then null else sum(arg)/count(arg) end
+				Else := &ast.BinaryOperationExpr{Op: opcode.Div, L: &avgSum, R: &avgCount}
+				When := ast.NewValueExpr(0, "", "")
+				Then := ast.NewValueExpr(nil, "", "")
+				aggf.Args[0] = &ast.CaseExpr{Value: &avgCount, WhenClauses: []*ast.WhenClause{{Expr: When, Result: Then}}, ElseClause: Else}
+			} else {
+				aggList = append(aggList, aggf)
+			}
+		}
+	} else {
+		aggList = extractor.AggFuncs
+	}
 	totalAggMapper := make(map[*ast.AggregateFuncExpr]int, len(aggList))
 
 	for i, agg := range aggList {
@@ -3382,6 +3404,7 @@ func (b *PlanBuilder) buildSelect(ctx context.Context, sel *ast.SelectStmt) (p L
 		if len(aggFuncs) == 0 && sel.GroupBy == nil {
 			hasAgg = false
 		}
+		fmt.Println("has aggs =  ", len(aggFuncs))
 	}
 	if hasAgg {
 		var aggIndexMap map[int]int

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -3404,7 +3404,6 @@ func (b *PlanBuilder) buildSelect(ctx context.Context, sel *ast.SelectStmt) (p L
 		if len(aggFuncs) == 0 && sel.GroupBy == nil {
 			hasAgg = false
 		}
-		fmt.Println("has aggs =  ", len(aggFuncs))
 	}
 	if hasAgg {
 		var aggIndexMap map[int]int


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary: we cannot push down avg to tiflash entalily, so we rewrite it to `case count(arg) when 0 then null else sum(arg)/count(arg) end`, then the `sum(arg)` and `count(arg)` can be pushed down.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

How it Works:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

```

mysql>  set @@tidb_allow_mpp=1; set @@tidb_opt_broadcast_join=1;
Query OK, 0 rows affected (0.00 sec)

Query OK, 0 rows affected (0.00 sec)

mysql> select value, avg(id)+1 as b from t1 group by value;
+-------+---------+
| value | b       |
+-------+---------+
|    11 |    NULL |
|    12 |    NULL |
|    10 | 10.0000 |
|     6 |  5.0000 |
|     2 |  2.0000 |
|     5 |  4.0000 |
|     8 |  8.0000 |
|     4 |  4.0000 |
+-------+---------+
8 rows in set (0.01 sec)

mysql> desc select value, avg(id)+1 as b from t1 group by value;
+------------------------------------+---------+--------------+---------------+--------------------------------------------------------------------------------------------------------------------------------------+
| id                                 | estRows | task         | access object | operator info                                                                                                                        |
+------------------------------------+---------+--------------+---------------+--------------------------------------------------------------------------------------------------------------------------------------+
| Projection_4                       | 7.20    | root         |               | test.t1.value, plus(case(eq(Column#4, 0), <nil>, div(Column#5, cast(Column#4, decimal(20,0) BINARY))), 1)->Column#6                  |
| └─TableReader_32                   | 7.20    | root         |               | data:ExchangeSender_31                                                                                                               |
|   └─ExchangeSender_31              | 7.20    | cop[tiflash] |               | ExchangeType: PassThrough                                                                                                            |
|     └─HashAgg_28                   | 7.20    | cop[tiflash] |               | group by:test.t1.value, funcs:sum(Column#14)->Column#4, funcs:sum(Column#15)->Column#5, funcs:firstrow(test.t1.value)->test.t1.value |
|       └─ExchangeReceiver_30        | 7.20    | cop[tiflash] |               |                                                                                                                                      |
|         └─ExchangeSender_29        | 7.20    | cop[tiflash] |               | ExchangeType: HashPartition, Hash Cols: test.t1.value                                                                                |
|           └─HashAgg_10             | 7.20    | cop[tiflash] |               | group by:test.t1.value, funcs:count(test.t1.id)->Column#14, funcs:sum(test.t1.id)->Column#15                                         |
|             └─TableFullScan_27     | 9.00    | cop[tiflash] | table:t1      | keep order:false, stats:pseudo                                                                                                       |
+------------------------------------+---------+--------------+---------------+--------------------------------------------------------------------------------------------------------------------------------------+
8 rows in set (0.00 sec)

mysql> select  avg(id)+1 from t1 where value=-1;
+-----------+
| avg(id)+1 |
+-----------+
|      NULL |
+-----------+
1 row in set (0.01 sec)

mysql> desc select  avg(id)+1 from t1 where value=-1;
+--------------------------------+---------+--------------+---------------+------------------------------------------------------------------------------------------------------+
| id                             | estRows | task         | access object | operator info                                                                                        |
+--------------------------------+---------+--------------+---------------+------------------------------------------------------------------------------------------------------+
| Projection_5                   | 1.00    | root         |               | plus(case(eq(Column#4, 0), <nil>, div(Column#5, cast(Column#4, decimal(20,0) BINARY))), 1)->Column#6 |
| └─StreamAgg_12                 | 1.00    | root         |               | funcs:count(Column#16)->Column#4, funcs:sum(Column#17)->Column#5                                     |
|   └─Projection_36              | 0.01    | root         |               | test.t1.id, cast(test.t1.id, decimal(32,0) BINARY)->Column#17                                        |
|     └─TableReader_28           | 0.01    | root         |               | data:Selection_27                                                                                    |
|       └─Selection_27           | 0.01    | cop[tiflash] |               | eq(test.t1.value, -1)                                                                                |
|         └─TableFullScan_26     | 9.00    | cop[tiflash] | table:t1      | keep order:false, stats:pseudo                                                                       |
+--------------------------------+---------+--------------+---------------+------------------------------------------------------------------------------------------------------+
6 rows in set (0.00 sec)

mysql> select value, avg(id) from t1 where value=-1 group by value;
Empty set (0.01 sec)

mysql> desc select value, avg(id) from t1 where value=-1 group by value;
+--------------------------------------+---------+--------------+---------------+--------------------------------------------------------------------------------------------------------------------------------------+
| id                                   | estRows | task         | access object | operator info                                                                                                                        |
+--------------------------------------+---------+--------------+---------------+--------------------------------------------------------------------------------------------------------------------------------------+
| Projection_5                         | 1.00    | root         |               | test.t1.value, case(eq(Column#4, 0), <nil>, div(Column#5, cast(Column#4, decimal(20,0) BINARY)))->Column#6                           |
| └─TableReader_40                     | 1.00    | root         |               | data:ExchangeSender_39                                                                                                               |
|   └─ExchangeSender_39                | 1.00    | cop[tiflash] |               | ExchangeType: PassThrough                                                                                                            |
|     └─HashAgg_36                     | 1.00    | cop[tiflash] |               | group by:test.t1.value, funcs:sum(Column#14)->Column#4, funcs:sum(Column#15)->Column#5, funcs:firstrow(test.t1.value)->test.t1.value |
|       └─ExchangeReceiver_38          | 1.00    | cop[tiflash] |               |                                                                                                                                      |
|         └─ExchangeSender_37          | 1.00    | cop[tiflash] |               | ExchangeType: HashPartition, Hash Cols: test.t1.value                                                                                |
|           └─HashAgg_11               | 1.00    | cop[tiflash] |               | group by:test.t1.value, funcs:count(test.t1.id)->Column#14, funcs:sum(test.t1.id)->Column#15                                         |
|             └─Selection_35           | 0.01    | cop[tiflash] |               | eq(test.t1.value, -1)                                                                                                                |
|               └─TableFullScan_34     | 9.00    | cop[tiflash] | table:t1      | keep order:false, stats:pseudo                                                                                                       |
+--------------------------------------+---------+--------------+---------------+--------------------------------------------------------------------------------------------------------------------------------------+
9 rows in set (0.00 sec)

```

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- No release note<!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
